### PR TITLE
Added .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: go
+
+go:
+  - 1.0
+  - 1.1
+
+matrix:
+  allowed_failures:
+    go:
+      - tip


### PR DESCRIPTION
I've added a `.travis.yml` file, which allows goworker to be tested on [Travis CI](http://travis-ci.org). If you want to set it up, you'll need to follow the [setup instructions](http://about.travis-ci.org/docs/user/getting-started/#Step-one%3A-Sign-in).
