### PR TITLE
When polling jobs from multiple queues randomize which queue we pull from

### DIFF
--- a/poller.go
+++ b/poller.go
@@ -4,6 +4,7 @@ import (
 	"code.google.com/p/vitess/go/pools"
 	"encoding/json"
 	"fmt"
+	"math/rand"
 	"time"
 )
 
@@ -22,7 +23,8 @@ func newPoller(queues []string) (*poller, error) {
 }
 
 func (p *poller) getJob(conn *redisConn) (*job, error) {
-	for _, queue := range p.Queues {
+	for _, index := range rand.Perm(len(p.Queues)) {
+		queue := p.Queues[index]
 		logger.Debugf("Checking %s", queue)
 
 		reply, err := conn.Do("LPOP", fmt.Sprintf("%squeue:%s", namespace, queue))


### PR DESCRIPTION
Given 2 queues Q1 and Q2 where either Q1 or both of them have  a lot of jobs scheduled
then it is possible for Q2 to starve. In this patch we randomize which queue we
pull from on each request.

Although this way we loose the ability to prioritize queues based on their order
in --queues in effect it seems like a small price to pay in environments where
multiple queues have a lot of jobs.

I tried to look to see if the prioritization of queues is a documented behavior in Resque but I couldn't any documents. If it is then please ignore this request.
