### PR TITLE
Ability to assign weights to queues.

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ end
 
 There are several flags which control the operation of the goworker client.
 
-* `-queues="comma,delimited,queues"` — This is the only required flag. The recommended practice is to separate your Resque workers from your goworkers with different queues. Otherwise, Resque worker classes that have no goworker analog will cause the goworker process to fail the jobs. Because of this, there is no default queue, nor is there a way to select all queues (à la Resque's `*` queue).
+* `-queues="comma,delimited,queues"` — This is the only required flag. The recommended practice is to separate your Resque workers from your goworkers with different queues. Otherwise, Resque worker classes that have no goworker analog will cause the goworker process to fail the jobs. Because of this, there is no default queue, nor is there a way to select all queues (à la Resque's `*` queue). If you have multiple queues you can assign them weights. A queue with a weight of 2 will be checked twice as often as a queue with a weight of 1: -queues='high=2,low=1'
 * `-interval=5.0` — Specifies the wait period between polling if no job was in the queue the last time one was requested.
 * `-concurrency=25` — Specifies the number of concurrently executing workers. This number can be as low as 1 or rather comfortably as high as 100,000, and should be tuned to your workflow and the availability of outside resources.
 * `-connections=2` — Specifies the maximum number of Redis connections that goworker will consume between the poller and all workers. There is not much performance gain over two and a slight penalty when using only one. This is configurable in case you need to keep connection counts low for cloud Redis providers who limit plans on `maxclients`.

--- a/flags.go
+++ b/flags.go
@@ -19,7 +19,12 @@
 // cause the goworker process to fail the jobs.
 // Because of this, there is no default queue,
 // nor is there a way to select all queues (à la
-// Resque's * queue).
+// Resque's * queue). Queues are processed in
+// the order they are specififed.
+// If you have multiple queues you can assign
+// them weights. A queue with a weight of 2 will
+//  be checked twice as often as a queue with a
+// weight of 1: -queues='high=2,low=1'
 //
 // -interval=5.0
 // — Specifies the wait period between polling if
@@ -75,6 +80,7 @@ package goworker
 import (
 	"flag"
 	"os"
+	"strings"
 )
 
 var (
@@ -87,6 +93,7 @@ var (
 	uri            string
 	namespace      string
 	exitOnComplete bool
+	isStrict       bool
 )
 
 func init() {
@@ -125,5 +132,6 @@ func flags() error {
 	if err := interval.SetFloat(intervalFloat); err != nil {
 		return err
 	}
+	isStrict = strings.IndexRune(queuesString, '=') == -1
 	return nil
 }

--- a/goworker.go
+++ b/goworker.go
@@ -31,7 +31,7 @@ func Work() error {
 	pool := newRedisPool(uri, connections, connections, time.Minute)
 	defer pool.Close()
 
-	poller, err := newPoller(queues)
+	poller, err := newPoller(queues, isStrict)
 	if err != nil {
 		return err
 	}

--- a/poller.go
+++ b/poller.go
@@ -9,20 +9,22 @@ import (
 
 type poller struct {
 	process
+	isStrict bool
 }
 
-func newPoller(queues []string) (*poller, error) {
+func newPoller(queues []string, isStrict bool) (*poller, error) {
 	process, err := newProcess("poller", queues)
 	if err != nil {
 		return nil, err
 	}
 	return &poller{
-		process: *process,
+		process:  *process,
+		isStrict: isStrict,
 	}, nil
 }
 
 func (p *poller) getJob(conn *redisConn) (*job, error) {
-	for _, queue := range p.Queues {
+	for _, queue := range p.queues(p.isStrict) {
 		logger.Debugf("Checking %s", queue)
 
 		reply, err := conn.Do("LPOP", fmt.Sprintf("%squeue:%s", namespace, queue))

--- a/process.go
+++ b/process.go
@@ -2,6 +2,7 @@ package goworker
 
 import (
 	"fmt"
+	"math/rand"
 	"os"
 	"strings"
 	"time"
@@ -72,4 +73,18 @@ func (p *process) fail(conn *redisConn) error {
 	conn.Flush()
 
 	return nil
+}
+
+func (p *process) queues(strict bool) []string {
+	//If the queues order is strict then just return them
+	if strict {
+		return p.Queues
+	}
+
+	//If not then we want to to shuffle the queues before returning them
+	queues := make([]string, len(p.Queues))
+	for i, v := range rand.Perm(len(p.Queues)) {
+		queues[i] = p.Queues[v]
+	}
+	return queues
 }

--- a/queues_flag.go
+++ b/queues_flag.go
@@ -3,24 +3,69 @@ package goworker
 import (
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 )
 
 var (
-	errorEmptyQueues = errors.New("You must specify at least one queue.")
+	errorEmptyQueues       = errors.New("You must specify at least one queue.")
+	errorNoneNumericWeight = errors.New("The weight must be a numeric value.")
 )
 
 type queuesFlag []string
 
 func (q *queuesFlag) Set(value string) error {
+
 	if value == "" {
 		return errorEmptyQueues
 	}
+	//Parse the individual queues and their weights if they are present.
+	for _, queueAndWeight := range strings.Split(value, ",") {
+		queue, weight, err := parseQueueAndWeight(queueAndWeight)
+		if err != nil {
+			return err
+		}
 
-	*q = append(*q, strings.Split(value, ",")...)
+		for i := 0; i < weight; i++ {
+			*q = append(*q, queue)
+		}
+	}
 	return nil
 }
 
 func (q *queuesFlag) String() string {
 	return fmt.Sprint(*q)
+}
+
+func parseQueueAndWeight(queueAndWeight string) (queue string, weight int, err error) {
+	parts := strings.Split(queueAndWeight, "=")
+	// There must be exactly one '=' in queue/weight declaration
+	if len(parts) > 2 {
+		return "", 0, errorNoneNumericWeight
+	}
+
+	//The empty string is a valid queue name, and has the default weight of 1
+	if len(parts) == 0 {
+		return "", 1, nil
+	}
+
+	//If '=' is not present then we only have the queue name and the default weight is 1
+	if len(parts) == 1 {
+		queue = parts[0]
+		weight = 1
+		err = nil
+		return
+	}
+
+	//Check to see if we have a weight for this queue
+	if len(parts) == 2 {
+		queue = parts[0]
+		weight, err = strconv.Atoi(parts[1])
+		if err != nil {
+			return "", 0, errorNoneNumericWeight
+		}
+		return queue, weight, nil
+	}
+	return
+
 }

--- a/queues_flag_test.go
+++ b/queues_flag_test.go
@@ -26,6 +26,21 @@ var queuesFlagSetTests = []struct {
 		queuesFlag([]string{"high", "low"}),
 		nil,
 	},
+	{
+		"high=2,low=1",
+		queuesFlag([]string{"high", "high", "low"}),
+		nil,
+	},
+	{
+		"high=2,low",
+		queuesFlag([]string{"high", "high", "low"}),
+		nil,
+	},
+	{
+		"low=1,high=2",
+		queuesFlag([]string{"low", "high", "high"}),
+		nil,
+	},
 }
 
 func TestQueuesFlagSet(t *testing.T) {
@@ -62,4 +77,57 @@ func TestQueuesFlagString(t *testing.T) {
 			t.Errorf("QueuesFlag(%#v): expected %s, actual %s", tt.q, tt.expected, actual)
 		}
 	}
+}
+
+func TestParseQueueAndWeight(t *testing.T) {
+	for _, tt := range parseQueueAndWeightTests {
+		queue, weight, err := parseQueueAndWeight(tt.queueAndWeight)
+		if queue != tt.queue {
+			t.Errorf("parseQueueAndWeight#queue expected %s, actual %s", tt.queue, queue)
+		}
+		if weight != tt.weight {
+			t.Errorf("parseQueueAndWeight#weight expected %d, actual %d", tt.weight, weight)
+		}
+		if err != tt.err {
+			t.Errorf("parseQueueAndWeight#err expected %v, actual %v", tt.err, err)
+		}
+	}
+}
+
+var parseQueueAndWeightTests = []struct {
+	queueAndWeight string
+	queue          string
+	weight         int
+	err            error
+}{
+	{
+		"q==",
+		"",
+		0,
+		errorNoneNumericWeight,
+	},
+	{
+		"q=a",
+		"",
+		0,
+		errorNoneNumericWeight,
+	},
+	{
+		"",
+		"",
+		1,
+		nil,
+	},
+	{
+		"q",
+		"q",
+		1,
+		nil,
+	},
+	{
+		"q=2",
+		"q",
+		2,
+		nil,
+	},
 }


### PR DESCRIPTION
When using multiple queues it is now possible to pass a weight for each queue
in the form of -queues=hight=2,low=1 which would result in a job being selected
at random from [high, high, low]
If no weights are provided queues are processed in the strict order they are
provided. e.g. -queues=high,low would result in the queue high being checked
first and if no jobs are present then we would check the queue low.

Fixes gh-4
