### PR TITLE
When managing a process don't ignore redis errors

### DIFF
--- a/process.go
+++ b/process.go
@@ -36,9 +36,7 @@ func (p *process) open(conn *redisConn) error {
 	conn.Send("SADD", fmt.Sprintf("%sworkers", namespace), p)
 	conn.Send("SET", fmt.Sprintf("%sstat:processed:%v", namespace, p), "0")
 	conn.Send("SET", fmt.Sprintf("%sstat:failed:%v", namespace, p), "0")
-	conn.Flush()
-
-	return nil
+	return conn.Flush()
 }
 
 func (p *process) close(conn *redisConn) error {
@@ -46,30 +44,22 @@ func (p *process) close(conn *redisConn) error {
 	conn.Send("SREM", fmt.Sprintf("%sworkers", namespace), p)
 	conn.Send("DEL", fmt.Sprintf("%sstat:processed:%s", namespace, p))
 	conn.Send("DEL", fmt.Sprintf("%sstat:failed:%s", namespace, p))
-	conn.Flush()
-
-	return nil
+	return conn.Flush()
 }
 
 func (p *process) start(conn *redisConn) error {
 	conn.Send("SET", fmt.Sprintf("%sworker:%s:started", namespace, p), time.Now().String())
-	conn.Flush()
-
-	return nil
+	return conn.Flush()
 }
 
 func (p *process) finish(conn *redisConn) error {
 	conn.Send("DEL", fmt.Sprintf("%sworker:%s", namespace, p))
 	conn.Send("DEL", fmt.Sprintf("%sworker:%s:started", namespace, p))
-	conn.Flush()
-
-	return nil
+	return conn.Flush()
 }
 
 func (p *process) fail(conn *redisConn) error {
 	conn.Send("INCR", fmt.Sprintf("%sstat:failed", namespace))
 	conn.Send("INCR", fmt.Sprintf("%sstat:failed:%s", namespace, p))
-	conn.Flush()
-
-	return nil
+	return conn.Flush()
 }


### PR DESCRIPTION
Return the error from conn.Flush() instead of returning nil
