### PR TITLE
Fetch the default queues value from the env

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -97,7 +97,7 @@ var (
 )
 
 func init() {
-	flag.StringVar(&queuesString, "queues", "", "a comma-separated list of Resque queues")
+	flag.StringVar(&queuesString, "queues", os.Getenv("QUEUES"), "a comma-separated list of Resque queues [QUEUES]")
 
 	flag.Float64Var(&intervalFloat, "interval", 5.0, "sleep interval when no jobs are found")
 


### PR DESCRIPTION
mostly so that purely env-based configurations are possible, as this is the only flag (I think?) that causes an exit when not provided.