### PR TITLE
Add goworker.Enqueue function (proposal)

### DIFF
--- a/enqueue.go
+++ b/enqueue.go
@@ -24,7 +24,7 @@ func Enqueue(queue string, class string, args []interface{}) error {
 	if err != nil {
 		return err
 	}
-	err = conn.Send("RPUSH", fmt.Sprintf("resque:queue:%s", queue), b)
+	err = conn.Send("RPUSH", fmt.Sprintf("%s%s", namespace, queue), b)
 	conn.Flush()
 	if err != nil {
 		return err

--- a/enqueue.go
+++ b/enqueue.go
@@ -5,29 +5,37 @@ import (
 	"fmt"
 )
 
-/*
-Enqueue function let you enqueue a new job in Resque given
-the queue, the class name and the parameters.
-*/
-func Enqueue(queue string, class string, args []interface{}) error {
-	conn, err := redisConnFromUri(uri)
-	if err != nil {
-		return err
-	}
-	defer conn.Close()
-
+// Enqueue function let you asynchronously enqueue a new job in Resque given
+// the queue, the class name and the parameters.
+//
+// param queue: name of the queue (not including the namespace)
+// param class: name of the Worker that can handle this job
+// param args:  arguments to pass to the handler function. Must be the non-marshalled version.
+//
+// return an error if args cannot be marshalled
+func Enqueue(queue string, class string, args []interface{}) (err error) {
+	pool := getConnectionPool()
 	data := &payload{
 		Class: class,
 		Args:  args,
 	}
 	b, err := json.Marshal(data)
 	if err != nil {
-		return err
+		return
 	}
-	err = conn.Send("RPUSH", fmt.Sprintf("%squeue:%s", namespace, queue), b)
-	conn.Flush()
+	resource, err := pool.Get()
 	if err != nil {
-		return err
+		logger.Criticalf("Error on getting connection in goworker.Enqueue(%s, %s, %v)", queue, class, args)
+		return
 	}
-	return nil
+	conn := resource.(*redisConn)
+	err = conn.Send("RPUSH", fmt.Sprintf("%squeue:%s", namespace, queue), b)
+	pool.Put(conn)
+	if err != nil {
+		logger.Criticalf("Cannot push message to redis in goworker.Enqueue(%s, %s, %v)", queue, class, args)
+		return
+	}
+
+	conn.Flush()
+	return
 }

--- a/enqueue.go
+++ b/enqueue.go
@@ -1,0 +1,33 @@
+package goworker
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+/*
+Enqueue function let you enqueue a new job in Resque given
+the queue, the class name and the parameters.
+*/
+func Enqueue(queue string, class string, args []interface{}) error {
+	conn, err := redisConnFromUri(uri)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	data := &payload{
+		Class: class,
+		Args:  args,
+	}
+	b, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+	err = conn.Send("RPUSH", fmt.Sprintf("resque:queue:%s", queue), b)
+	conn.Flush()
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/enqueue_test.go
+++ b/enqueue_test.go
@@ -5,13 +5,15 @@ import (
 	"fmt"
 	"github.com/garyburd/redigo/redis"
 	"testing"
+	"time"
 )
 
 func TestEnqueueHasNoDeadlock(t *testing.T) {
+	p := newRedisPool(uri, 1, 1, time.Minute)
+	defer p.Close()
+
 	exitOnComplete = true
-	connections = 1
 	queues.Set("test_enqueue_has_no_deadlock")
-	concurrency = 1
 	jobProcessed := false
 	Register("NoDeadLock", func(q string, args ...interface{}) error {
 		Enqueue("dummy", "Dummy", nil)
@@ -19,24 +21,30 @@ func TestEnqueueHasNoDeadlock(t *testing.T) {
 		return nil
 	})
 	Enqueue("test_enqueue_has_no_deadlock", "NoDeadLock", nil)
-	err := Work()
+	err := WorkWithPool(p)
 	if !jobProcessed {
 		t.Error("job has not been processed")
 	}
 	if err != nil {
 		t.Errorf("Error occured %v", err)
 	}
-	resource, _ := pool.Get()
+	if p.IsClosed() {
+		t.Error("Pool should not be closed")
+	}
+	resource, _ := p.Get()
 	conn := resource.(*redisConn)
-	defer pool.Put(conn)
+	defer p.Put(conn)
 	defer conn.Do("DEL", fmt.Sprintf("%squeue:dummy", namespace))
 	defer conn.Do("DEL", fmt.Sprintf("%squeue:test_enqueue_has_no_deadlock", namespace))
 }
 
 func TestEnqueueWriteToRedis(t *testing.T) {
+	p := newRedisPool(uri, 1, 1, time.Minute)
+	defer p.Close()
+
 	queues.Set("no")
 	Enqueue("test2", "TestEnqueueWriteToRedis", nil)
-	Work()
+	WorkWithPool(p)
 	resource, _ := pool.Get()
 	conn := resource.(*redisConn)
 	defer pool.Put(conn)

--- a/enqueue_test.go
+++ b/enqueue_test.go
@@ -1,0 +1,54 @@
+package goworker
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/garyburd/redigo/redis"
+	"testing"
+)
+
+func TestEnqueueHasNoDeadlock(t *testing.T) {
+	exitOnComplete = true
+	connections = 1
+	queues.Set("test_enqueue_has_no_deadlock")
+	concurrency = 1
+	jobProcessed := false
+	Register("NoDeadLock", func(q string, args ...interface{}) error {
+		Enqueue("dummy", "Dummy", nil)
+		jobProcessed = true
+		return nil
+	})
+	Enqueue("test_enqueue_has_no_deadlock", "NoDeadLock", nil)
+	err := Work()
+	if !jobProcessed {
+		t.Error("job has not been processed")
+	}
+	if err != nil {
+		t.Errorf("Error occured %v", err)
+	}
+	resource, _ := pool.Get()
+	conn := resource.(*redisConn)
+	defer pool.Put(conn)
+	defer conn.Do("DEL", fmt.Sprintf("%squeue:dummy", namespace))
+	defer conn.Do("DEL", fmt.Sprintf("%squeue:test_enqueue_has_no_deadlock", namespace))
+}
+
+func TestEnqueueWriteToRedis(t *testing.T) {
+	queues.Set("no")
+	Enqueue("test2", "TestEnqueueWriteToRedis", nil)
+	Work()
+	resource, _ := pool.Get()
+	conn := resource.(*redisConn)
+	defer pool.Put(conn)
+	defer conn.Do("DEL", fmt.Sprintf("%squeue:test2", namespace))
+	res, err := conn.Do("LPOP", fmt.Sprintf("%squeue:test2", namespace))
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+	jsonData, _ := redis.Bytes(res, nil)
+	var data map[string]interface{}
+	json.Unmarshal(jsonData, &data)
+	if data["class"] != "TestEnqueueWriteToRedis" {
+		t.Error(data["class"])
+	}
+}

--- a/goworker.go
+++ b/goworker.go
@@ -1,6 +1,7 @@
 package goworker
 
 import (
+	"code.google.com/p/vitess/go/pools"
 	"github.com/cihub/seelog"
 	"os"
 	"strconv"
@@ -16,18 +17,11 @@ var logger seelog.LoggerInterface
 // received, or until the queues are empty if the
 // -exit-on-complete flag is set.
 func Work() error {
-	var err error
-	logger, err = seelog.LoggerFromWriterWithMinLevel(os.Stdout, seelog.InfoLvl)
+	err := initEnv()
 	if err != nil {
 		return err
 	}
-
-	if err := flags(); err != nil {
-		return err
-	}
-
 	quit := signals()
-
 	poller, err := newPoller(queues, isStrict)
 	if err != nil {
 		return err
@@ -45,6 +39,25 @@ func Work() error {
 	}
 
 	monitor.Wait()
+	return nil
+}
 
+// Call this function to run goworker with the given pool.
+func WorkWithPool(pool *pools.ResourcePool) error {
+	setConnectionPool(pool)
+	return Work()
+}
+
+// Init logger and flags.
+func initEnv() error {
+	var err error
+	logger, err = seelog.LoggerFromWriterWithMinLevel(os.Stdout, seelog.InfoLvl)
+	if err != nil {
+		return err
+	}
+
+	if err := flags(); err != nil {
+		return err
+	}
 	return nil
 }

--- a/goworker.go
+++ b/goworker.go
@@ -28,14 +28,11 @@ func Work() error {
 
 	quit := signals()
 
-	pool := newRedisPool(uri, connections, connections, time.Minute)
-	defer pool.Close()
-
 	poller, err := newPoller(queues, isStrict)
 	if err != nil {
 		return err
 	}
-	jobs := poller.poll(pool, time.Duration(interval), quit)
+	jobs := poller.poll(getConnectionPool(), time.Duration(interval), quit)
 
 	var monitor sync.WaitGroup
 
@@ -44,7 +41,7 @@ func Work() error {
 		if err != nil {
 			return err
 		}
-		worker.work(pool, jobs, &monitor)
+		worker.work(getConnectionPool(), jobs, &monitor)
 	}
 
 	monitor.Wait()

--- a/goworker.go
+++ b/goworker.go
@@ -58,7 +58,7 @@ func startWithPool(p *pools.ResourcePool) error {
 	if err != nil {
 		return err
 	}
-	jobs := poller.poll(getConnectionPool(), time.Duration(interval), quit)
+	jobs := poller.poll(p, time.Duration(interval), quit)
 
 	var monitor sync.WaitGroup
 
@@ -67,7 +67,7 @@ func startWithPool(p *pools.ResourcePool) error {
 		if err != nil {
 			return err
 		}
-		worker.work(getConnectionPool(), jobs, &monitor)
+		worker.work(p, jobs, &monitor)
 	}
 
 	monitor.Wait()

--- a/goworker.go
+++ b/goworker.go
@@ -1,7 +1,6 @@
 package goworker
 
 import (
-	"code.google.com/p/vitess/go/pools"
 	"github.com/cihub/seelog"
 	"os"
 	"strconv"
@@ -17,11 +16,18 @@ var logger seelog.LoggerInterface
 // received, or until the queues are empty if the
 // -exit-on-complete flag is set.
 func Work() error {
-	err := initEnv()
+	var err error
+	logger, err = seelog.LoggerFromWriterWithMinLevel(os.Stdout, seelog.InfoLvl)
 	if err != nil {
 		return err
 	}
+
+	if err := flags(); err != nil {
+		return err
+	}
+
 	quit := signals()
+
 	poller, err := newPoller(queues, isStrict)
 	if err != nil {
 		return err
@@ -39,25 +45,6 @@ func Work() error {
 	}
 
 	monitor.Wait()
-	return nil
-}
 
-// Call this function to run goworker with the given pool.
-func WorkWithPool(pool *pools.ResourcePool) error {
-	setConnectionPool(pool)
-	return Work()
-}
-
-// Init logger and flags.
-func initEnv() error {
-	var err error
-	logger, err = seelog.LoggerFromWriterWithMinLevel(os.Stdout, seelog.InfoLvl)
-	if err != nil {
-		return err
-	}
-
-	if err := flags(); err != nil {
-		return err
-	}
 	return nil
 }

--- a/redis.go
+++ b/redis.go
@@ -29,14 +29,6 @@ func getConnectionPool() *pools.ResourcePool {
 	return pool
 }
 
-// Manually defines a connection pool
-func setConnectionPool(p *pools.ResourcePool) {
-	if !(pool == nil || pool.IsClosed()) {
-		pool.Close()
-	}
-	pool = p
-}
-
 func newRedisFactory(uri string) pools.Factory {
 	return func() (pools.Resource, error) {
 		return redisConnFromUri(uri)

--- a/redis.go
+++ b/redis.go
@@ -10,6 +10,7 @@ import (
 
 var (
 	errorInvalidScheme = errors.New("Invalid Redis database URI scheme.")
+	pool               *pools.ResourcePool
 )
 
 type redisConn struct {
@@ -18,6 +19,14 @@ type redisConn struct {
 
 func (r *redisConn) Close() {
 	_ = r.Conn.Close()
+}
+
+// Retrieve a redis pool
+func getConnectionPool() *pools.ResourcePool {
+	if pool == nil || pool.IsClosed() {
+		pool = newRedisPool(uri, connections, connections, time.Minute)
+	}
+	return pool
 }
 
 func newRedisFactory(uri string) pools.Factory {

--- a/redis.go
+++ b/redis.go
@@ -29,6 +29,14 @@ func getConnectionPool() *pools.ResourcePool {
 	return pool
 }
 
+// Manually defines a connection pool
+func setConnectionPool(p *pools.ResourcePool) {
+	if !(pool == nil || pool.IsClosed()) {
+		pool.Close()
+	}
+	pool = p
+}
+
 func newRedisFactory(uri string) pools.Factory {
 	return func() (pools.Resource, error) {
 		return redisConnFromUri(uri)


### PR DESCRIPTION
This is a proposal to add an Enqueue function based on issue #1 discussion.

There is at least one  issue that I would like to discuss:

_Package scoped getConnectionPool func:_

To be able to use the same Redis connection pool implies to write a package scoped method that will create the pool if needed and return it. This modify the actual code by not allowing Work() func to close the pool at the end. We can still close it but it means we will re-create a pool next time Enqueue() will be called and again, Enqueue should not close the pool either.

Any idea on how to solve this in a better way

It's my first contribution to a Go project and I'm far from an expert with this language, so any guidance is welcome.