### PR TITLE
Added goworker.WorkWithPool method

### DIFF
--- a/goworker.go
+++ b/goworker.go
@@ -26,11 +26,13 @@ func Work() error {
 	return startWithPool(pool)
 }
 
+// Call this function to run goworker with the given pool.
 func WorkWithPool(pool *pools.ResourcePool) error {
 	initEnv()
 	return startWithPool(pool)
 }
 
+// Init logger and flags.
 func initEnv() error {
 	var err error
 	logger, err = seelog.LoggerFromWriterWithMinLevel(os.Stdout, seelog.InfoLvl)
@@ -44,6 +46,7 @@ func initEnv() error {
 	return nil
 }
 
+// Start worker with the given pool.
 func startWithPool(pool *pools.ResourcePool) error {
 	quit := signals()
 	poller, err := newPoller(queues, isStrict)

--- a/goworker.go
+++ b/goworker.go
@@ -28,7 +28,10 @@ func Work() error {
 
 // Call this function to run goworker with the given pool.
 func WorkWithPool(pool *pools.ResourcePool) error {
-	initEnv()
+	err := initEnv()
+	if err != nil {
+		return err
+	}
 	return startWithPool(pool)
 }
 


### PR DESCRIPTION
Enable one to work with a pool injected from outside. This is a kind of a naive proposal.

A better, more complete, implementation might be to create a method goworker.WorkWithConfiguration(config) where config is a struct that supports all the flags and a pool instance.

What do you think?

fixes #12