### PR TITLE
dont need to specify colon in namespace param

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -133,7 +133,7 @@ func init() {
 	}
 	flag.StringVar(&uri, "uri", redisEnvUri, "the URI of the Redis server")
 
-	flag.StringVar(&namespace, "namespace", "resque:", "the Redis namespace")
+	flag.StringVar(&namespace, "namespace", "resque", "the Redis namespace")
 
 	flag.BoolVar(&exitOnComplete, "exit-on-complete", false, "exit when the queue is empty")
 

--- a/poller.go
+++ b/poller.go
@@ -27,7 +27,7 @@ func (p *poller) getJob(conn *RedisConn) (*job, error) {
 	for _, queue := range p.queues(p.isStrict) {
 		logger.Debugf("Checking %s", queue)
 
-		reply, err := conn.Do("LPOP", fmt.Sprintf("%squeue:%s", namespace, queue))
+		reply, err := conn.Do("LPOP", fmt.Sprintf("%s:queue:%s", namespace, queue))
 		if err != nil {
 			return nil, err
 		}
@@ -98,7 +98,7 @@ func (p *poller) poll(interval time.Duration, quit <-chan bool) <-chan *job {
 					return
 				}
 				if job != nil {
-					conn.Send("INCR", fmt.Sprintf("%sstat:processed:%v", namespace, p))
+					conn.Send("INCR", fmt.Sprintf("%s:stat:processed:%v", namespace, p))
 					conn.Flush()
 					PutConn(conn)
 					select {
@@ -115,7 +115,7 @@ func (p *poller) poll(interval time.Duration, quit <-chan bool) <-chan *job {
 							return
 						}
 
-						conn.Send("LPUSH", fmt.Sprintf("%squeue:%s", namespace, job.Queue), buf)
+						conn.Send("LPUSH", fmt.Sprintf("%s:queue:%s", namespace, job.Queue), buf)
 						conn.Flush()
 						return
 					}

--- a/process.go
+++ b/process.go
@@ -34,9 +34,9 @@ func (p *process) String() string {
 }
 
 func (p *process) open(conn *RedisConn) error {
-	conn.Send("SADD", fmt.Sprintf("%sworkers", namespace), p)
-	conn.Send("SET", fmt.Sprintf("%sstat:processed:%v", namespace, p), "0")
-	conn.Send("SET", fmt.Sprintf("%sstat:failed:%v", namespace, p), "0")
+	conn.Send("SADD", fmt.Sprintf("%s:workers", namespace), p)
+	conn.Send("SET", fmt.Sprintf("%s:stat:processed:%v", namespace, p), "0")
+	conn.Send("SET", fmt.Sprintf("%s:stat:failed:%v", namespace, p), "0")
 	conn.Flush()
 
 	return nil
@@ -44,32 +44,32 @@ func (p *process) open(conn *RedisConn) error {
 
 func (p *process) close(conn *RedisConn) error {
 	logger.Infof("%v shutdown", p)
-	conn.Send("SREM", fmt.Sprintf("%sworkers", namespace), p)
-	conn.Send("DEL", fmt.Sprintf("%sstat:processed:%s", namespace, p))
-	conn.Send("DEL", fmt.Sprintf("%sstat:failed:%s", namespace, p))
+	conn.Send("SREM", fmt.Sprintf("%s:workers", namespace), p)
+	conn.Send("DEL", fmt.Sprintf("%s:stat:processed:%s", namespace, p))
+	conn.Send("DEL", fmt.Sprintf("%s:stat:failed:%s", namespace, p))
 	conn.Flush()
 
 	return nil
 }
 
 func (p *process) start(conn *RedisConn) error {
-	conn.Send("SET", fmt.Sprintf("%sworker:%s:started", namespace, p), time.Now().String())
+	conn.Send("SET", fmt.Sprintf("%s:worker:%s:started", namespace, p), time.Now().String())
 	conn.Flush()
 
 	return nil
 }
 
 func (p *process) finish(conn *RedisConn) error {
-	conn.Send("DEL", fmt.Sprintf("%sworker:%s", namespace, p))
-	conn.Send("DEL", fmt.Sprintf("%sworker:%s:started", namespace, p))
+	conn.Send("DEL", fmt.Sprintf("%s:worker:%s", namespace, p))
+	conn.Send("DEL", fmt.Sprintf("%s:worker:%s:started", namespace, p))
 	conn.Flush()
 
 	return nil
 }
 
 func (p *process) fail(conn *RedisConn) error {
-	conn.Send("INCR", fmt.Sprintf("%sstat:failed", namespace))
-	conn.Send("INCR", fmt.Sprintf("%sstat:failed:%s", namespace, p))
+	conn.Send("INCR", fmt.Sprintf("%s:stat:failed", namespace))
+	conn.Send("INCR", fmt.Sprintf("%s:stat:failed:%s", namespace, p))
 	conn.Flush()
 
 	return nil

--- a/worker.go
+++ b/worker.go
@@ -38,7 +38,7 @@ func (w *worker) start(conn *RedisConn, job *job) error {
 		return err
 	}
 
-	conn.Send("SET", fmt.Sprintf("%sworker:%s", namespace, w), buffer)
+	conn.Send("SET", fmt.Sprintf("%s:worker:%s", namespace, w), buffer)
 	logger.Debugf("Processing %s since %s [%v]", work.Queue, work.RunAt, work.Payload.Class)
 
 	return w.process.start(conn)
@@ -57,14 +57,14 @@ func (w *worker) fail(conn *RedisConn, job *job, err error) error {
 	if err != nil {
 		return err
 	}
-	conn.Send("RPUSH", fmt.Sprintf("%sfailed", namespace), buffer)
+	conn.Send("RPUSH", fmt.Sprintf("%s:failed", namespace), buffer)
 
 	return w.process.fail(conn)
 }
 
 func (w *worker) succeed(conn *RedisConn, job *job) error {
-	conn.Send("INCR", fmt.Sprintf("%sstat:processed", namespace))
-	conn.Send("INCR", fmt.Sprintf("%sstat:processed:%s", namespace, w))
+	conn.Send("INCR", fmt.Sprintf("%s:stat:processed", namespace))
+	conn.Send("INCR", fmt.Sprintf("%s:stat:processed:%s", namespace, w))
 
 	return nil
 }


### PR DESCRIPTION
Does this make sense? Hopefully namespace doesn't have to end with a colon.