### PR TITLE
It was fixed because the path of 'package pools' has changed

### DIFF
--- a/goworker.go
+++ b/goworker.go
@@ -1,8 +1,8 @@
 package goworker
 
 import (
-	"code.google.com/p/vitess/go/pools"
 	"github.com/cihub/seelog"
+	"github.com/youtube/vitess/go/pools"
 	"os"
 	"strconv"
 	"sync"
@@ -41,7 +41,7 @@ func Init() error {
 // while they wait for an available connection. Expect this
 // API to change drastically.
 func GetConn() (*RedisConn, error) {
-	resource, err := pool.Get()
+	resource, err := pool.Get(nil)
 
 	if err != nil {
 		return nil, err

--- a/redis.go
+++ b/redis.go
@@ -1,9 +1,9 @@
 package goworker
 
 import (
-	"code.google.com/p/vitess/go/pools"
 	"errors"
 	"github.com/garyburd/redigo/redis"
+	"github.com/youtube/vitess/go/pools"
 	"net/url"
 	"time"
 )


### PR DESCRIPTION
I have tried to go get.

And then came the following error

```
$ go get code.google.com/p/vitess/go/pools 
package code.google.com/p/vitess/go/pools: unable to detect version control system for code.google.com/ path
```

It is apparently as `code.google.com/p/vitess/go/pools` has been changed to `github.com/youtube/vitess/go/pools`.

So I changed also path of import `code.google.com/p/vitess/go/pools`  : )

