### PR TITLE
parsing hostname from command line or env

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -103,6 +103,7 @@ var (
 	exitOnComplete bool
 	isStrict       bool
 	useNumber      bool
+	hostname       string
 )
 
 // Namespace returns the namespace flag for goworker. You
@@ -138,6 +139,9 @@ func init() {
 	flag.BoolVar(&exitOnComplete, "exit-on-complete", false, "exit when the queue is empty")
 
 	flag.BoolVar(&useNumber, "use-number", false, "use json.Number instead of float64 when decoding numbers in JSON. will default to true soon")
+
+	hostname = os.Getenv("HOSTNAME")
+	flag.StringVar(&hostname, "hostname", hostname, "custom hostname for resque workers")
 }
 
 func flags() error {

--- a/process.go
+++ b/process.go
@@ -16,9 +16,13 @@ type process struct {
 }
 
 func newProcess(id string, queues []string) (*process, error) {
-	hostname, err := os.Hostname()
-	if err != nil {
-		return nil, err
+	if hostname == "" {
+		h, err := os.Hostname()
+		if err != nil {
+			return nil, err
+		}
+
+		hostname = h
 	}
 
 	return &process{


### PR DESCRIPTION
A small change that enables setting a `hostname` via the command line or environment variables.

The motivation for this change is that Heroku has unreadable hostnames, and that makes it very hard to determine what sets of workers are doing what. The change is backwards compatible, nothing changes for users who don't set the hostname variable. I would prefer to change something else instead of `hostname`, but resque only shows that value in resque_web.

**Before**
<img width="457" alt="screen shot 2015-12-30 at 13 26 33" src="https://cloud.githubusercontent.com/assets/2500134/12051743/c4dbf148-af07-11e5-91b2-0fd907b6856b.png">

**After**
<img width="460" alt="screen shot 2015-12-30 at 14 59 21" src="https://cloud.githubusercontent.com/assets/2500134/12051744/c4f991d0-af07-11e5-9f19-8ee97b2475c5.png">
