### PR TITLE
correct variable name for worker settings in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ func init() {
 		Namespace:      "resque:",
 		Interval:       5.0,
 	}
-	goworker.SetSettings(workerSettings)
+	goworker.SetSettings(settings)
 	goworker.Register("MyClass", myFunc)
 }
 


### PR DESCRIPTION
The variable name for WorkerSettings is incorrectly referenced as `workerSettings` but it should be `settings`.