### PR TITLE
fix init after setSetting bug

### DIFF
--- a/goworker.go
+++ b/goworker.go
@@ -37,6 +37,8 @@ type WorkerSettings struct {
 }
 
 func SetSettings(settings WorkerSettings) {
+	// force the flags to be parsed first before setting the configs.
+	Init()
 	workerSettings = settings
 }
 


### PR DESCRIPTION
If the Init() is called after SetSetting(),

the flags() will replace the settings set previously.