### PR TITLE
Add the SADD to register a queue after using enqueue

### DIFF
--- a/workers.go
+++ b/workers.go
@@ -39,9 +39,16 @@ func Enqueue(job *Job) error {
 		logger.Criticalf("Cant marshal payload on enqueue")
 		return err
 	}
+
 	err = conn.Send("RPUSH", fmt.Sprintf("%squeue:%s", workerSettings.Namespace, job.Queue), buffer)
 	if err != nil {
 		logger.Criticalf("Cant push to queue")
+		return err
+	}
+
+	err = conn.Send("SADD", fmt.Sprintf("%squeues", workerSettings.Namespace), job.Queue)
+	if err != nil {
+		logger.Criticalf("Cant regiser queue to list of use queues")
 		return err
 	}
 

--- a/workers.go
+++ b/workers.go
@@ -48,7 +48,7 @@ func Enqueue(job *Job) error {
 
 	err = conn.Send("SADD", fmt.Sprintf("%squeues", workerSettings.Namespace), job.Queue)
 	if err != nil {
-		logger.Criticalf("Cant regiser queue to list of use queues")
+		logger.Criticalf("Cant register queue to list of use queues")
 		return err
 	}
 


### PR DESCRIPTION
For coherence with the Ruby implementation (and also for the ResqueWeb), when a job is enqueued, the queue must be added to the "resque:queues" this way the ResqueWeb can print it and the jobs that it has.

I don't know how to test this "feature" because the only way would be to query Redis for a `smembers resque:queues` and see if the queue is there (I've tested that it works on my PC). If this is ok for you I can add a test doing what I've described, but there is no test querying Redis so I prefer to ask first If you would do it this way 😄  