### PR TITLE
Fixed: Check in `conn` so that connection pool can be closed

### DIFF
--- a/poller.go
+++ b/poller.go
@@ -117,6 +117,7 @@ func (p *poller) poll(interval time.Duration, quit <-chan bool) <-chan *Job {
 
 						conn.Send("LPUSH", fmt.Sprintf("%squeue:%s", workerSettings.Namespace, job.Queue), buf)
 						conn.Flush()
+						PutConn(conn)
 						return
 					}
 				} else {


### PR DESCRIPTION
This pull request fixes a bug. I found the problem because when I typed ctrl-c, the application did not exit but blocked somewhere. It turned out that `PutConn(conn)` was missing after sending "LPUSH".