### PR TITLE
Log critical errors

### DIFF
--- a/poller.go
+++ b/poller.go
@@ -56,7 +56,7 @@ func (p *poller) poll(interval time.Duration, quit <-chan bool) <-chan *Job {
 
 	conn, err := GetConn()
 	if err != nil {
-		logger.Criticalf("Error on getting connection in poller %s", p)
+		logger.Criticalf("Error on getting connection in poller %s: %v", p, err)
 		close(jobs)
 		return jobs
 	} else {
@@ -71,7 +71,7 @@ func (p *poller) poll(interval time.Duration, quit <-chan bool) <-chan *Job {
 
 			conn, err := GetConn()
 			if err != nil {
-				logger.Criticalf("Error on getting connection in poller %s", p)
+				logger.Criticalf("Error on getting connection in poller %s: %v", p, err)
 				return
 			} else {
 				p.finish(conn)
@@ -87,7 +87,7 @@ func (p *poller) poll(interval time.Duration, quit <-chan bool) <-chan *Job {
 			default:
 				conn, err := GetConn()
 				if err != nil {
-					logger.Criticalf("Error on getting connection in poller %s", p)
+					logger.Criticalf("Error on getting connection in poller %s: %v", p, err)
 					return
 				}
 
@@ -111,7 +111,7 @@ func (p *poller) poll(interval time.Duration, quit <-chan bool) <-chan *Job {
 						}
 						conn, err := GetConn()
 						if err != nil {
-							logger.Criticalf("Error on getting connection in poller %s", p)
+							logger.Criticalf("Error on getting connection in poller %s: %v", p, err)
 							return
 						}
 

--- a/worker.go
+++ b/worker.go
@@ -81,7 +81,7 @@ func (w *worker) finish(conn *RedisConn, job *Job, err error) error {
 func (w *worker) work(jobs <-chan *Job, monitor *sync.WaitGroup) {
 	conn, err := GetConn()
 	if err != nil {
-		logger.Criticalf("Error on getting connection in worker %v", w)
+		logger.Criticalf("Error on getting connection in worker %v: %v", w, err)
 		return
 	} else {
 		w.open(conn)
@@ -96,7 +96,7 @@ func (w *worker) work(jobs <-chan *Job, monitor *sync.WaitGroup) {
 
 			conn, err := GetConn()
 			if err != nil {
-				logger.Criticalf("Error on getting connection in worker %v", w)
+				logger.Criticalf("Error on getting connection in worker %v: %v", w, err)
 				return
 			} else {
 				w.close(conn)
@@ -114,7 +114,7 @@ func (w *worker) work(jobs <-chan *Job, monitor *sync.WaitGroup) {
 
 				conn, err := GetConn()
 				if err != nil {
-					logger.Criticalf("Error on getting connection in worker %v", w)
+					logger.Criticalf("Error on getting connection in worker %v: %v", w, err)
 					return
 				} else {
 					w.finish(conn, job, errors.New(errorLog))
@@ -130,7 +130,7 @@ func (w *worker) run(job *Job, workerFunc workerFunc) {
 	defer func() {
 		conn, errCon := GetConn()
 		if errCon != nil {
-			logger.Criticalf("Error on getting connection in worker %v", w)
+			logger.Criticalf("Error on getting connection in worker on finish %v: %v", w, errCon)
 			return
 		} else {
 			w.finish(conn, job, err)
@@ -145,7 +145,7 @@ func (w *worker) run(job *Job, workerFunc workerFunc) {
 
 	conn, err := GetConn()
 	if err != nil {
-		logger.Criticalf("Error on getting connection in worker %v", w)
+		logger.Criticalf("Error on getting connection in worker on start %v: %v", w, err)
 		return
 	} else {
 		w.start(conn, job)


### PR DESCRIPTION
In some cases underlying connection errors are already logged but mostly not. This MR logs all of them.

I ran into this while working on Sentinel integration and while it is probably less of a problem with a single instance of Redis, I think that better visibility is useful as well.