### PR TITLE
Added error handling to Work

### DIFF
--- a/goworker.go
+++ b/goworker.go
@@ -127,7 +127,10 @@ func Work() error {
 	if err != nil {
 		return err
 	}
-	jobs := poller.poll(time.Duration(workerSettings.Interval), quit)
+	jobs, err := poller.poll(time.Duration(workerSettings.Interval), quit)
+	if err != nil {
+		return err
+	}
 
 	var monitor sync.WaitGroup
 

--- a/poller.go
+++ b/poller.go
@@ -51,14 +51,14 @@ func (p *poller) getJob(conn *RedisConn) (*Job, error) {
 	return nil, nil
 }
 
-func (p *poller) poll(interval time.Duration, quit <-chan bool) <-chan *Job {
+func (p *poller) poll(interval time.Duration, quit <-chan bool) (<-chan *Job, error) {
 	jobs := make(chan *Job)
 
 	conn, err := GetConn()
 	if err != nil {
 		logger.Criticalf("Error on getting connection in poller %s: %v", p, err)
 		close(jobs)
-		return jobs
+		return jobs, err
 	} else {
 		p.open(conn)
 		p.start(conn)
@@ -139,5 +139,5 @@ func (p *poller) poll(interval time.Duration, quit <-chan bool) <-chan *Job {
 		}
 	}()
 
-	return jobs
+	return jobs, nil
 }


### PR DESCRIPTION
Without this, `Work()` would only return an error in strange and somewhat irrelevant scenarios (ie, can't get the os hostname, or can't get a logger). It failed to catch if there was actually an error with the poller connecting to redis. This adds error handling so that `Work()` will actually return an error if the poller can't connect to redis, instead of just logging it out. This allowed me to implement some smart retry logic in the app I am working on. 
Did not fix tests as there is no mock for redis included and the tests seem to rely on this error not being handled properly.