### PR TITLE
When processes fail, provide a stacktrace to the Resque failure queue

### DIFF
--- a/worker.go
+++ b/worker.go
@@ -2,8 +2,8 @@ package goworker
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
+	"github.com/go-errors/errors"
 	"sync"
 	"time"
 )
@@ -49,7 +49,7 @@ func (w *worker) fail(conn *RedisConn, job *Job, err error) error {
 		FailedAt:  time.Now(),
 		Payload:   job.Payload,
 		Exception: "Error",
-		Error:     err.Error(),
+		Error:     err.(*errors.Error).ErrorStack(),
 		Worker:    w,
 		Queue:     job.Queue,
 	}
@@ -71,7 +71,7 @@ func (w *worker) succeed(conn *RedisConn, job *Job) error {
 
 func (w *worker) finish(conn *RedisConn, job *Job, err error) error {
 	if err != nil {
-		w.fail(conn, job, err)
+		w.fail(conn, job, errors.Wrap(err, 1))
 	} else {
 		w.succeed(conn, job)
 	}


### PR DESCRIPTION
Currently, when `goworker` workers fail due to an uncaught error, tracking down the root cause of the problem is rather difficult. Only the contents of the error is passed to the Resque failure queue, unlike other languages (e.g. Ruby), which pass the entire stack trace.

Golang's errors do not support stack traces out of the box. The [go-errors](github.com/go-errors/errors) package makes it possible to attach stack trace information to the errors either at creation-time, or at wrapping-time.

This pull request takes advantage of the idempotency of `go-errors`'s `Wrap()` function, allowing a worker to either raise a `go-errors` `error` object themselves, or automatically wrapping a standard Golang error when the failure is observed by `goworker`. A worker that throws a standard error will see the same information currently provided to the failure queue, with a stack trace pointing them to `goworker/worker.go` as the investigation point. A worker that wraps their standard error with `go-errors` will see that same information, plus a full stack trace to the point that the user instantiated/wrapped the `go-errors` error object.