### PR TITLE
Add TLS Support To goworker

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -121,7 +121,7 @@ func init() {
 
 	flag.StringVar(&workerSettings.Namespace, "namespace", "resque:", "the Redis namespace")
 
-	flag.StringVar(&workerSettings.TLSCertPath, "tlscert", "", "path to a custom CA cert")
+	flag.StringVar(&workerSettings.TLSCertPath, "tls-cert", "", "path to a custom CA cert")
 
 	flag.BoolVar(&workerSettings.ExitOnComplete, "exit-on-complete", false, "exit when the queue is empty")
 

--- a/flags.go
+++ b/flags.go
@@ -121,9 +121,13 @@ func init() {
 
 	flag.StringVar(&workerSettings.Namespace, "namespace", "resque:", "the Redis namespace")
 
+	flag.StringVar(&workerSettings.TLSCertPath, "tlscert", "", "path to a custom CA cert")
+
 	flag.BoolVar(&workerSettings.ExitOnComplete, "exit-on-complete", false, "exit when the queue is empty")
 
 	flag.BoolVar(&workerSettings.UseNumber, "use-number", false, "use json.Number instead of float64 when decoding numbers in JSON. will default to true soon")
+
+	flag.BoolVar(&workerSettings.SkipTLSVerify, "insecure-tls", false, "skip TLS validation")
 }
 
 func flags() error {

--- a/goworker.go
+++ b/goworker.go
@@ -34,6 +34,8 @@ type WorkerSettings struct {
 	ExitOnComplete bool
 	IsStrict       bool
 	UseNumber      bool
+	SkipTLSVerify  bool
+	TLSCertPath    string
 }
 
 func SetSettings(settings WorkerSettings) {


### PR DESCRIPTION
Greetings,

This pull request adds support for TLS on the Redis connection.  To create a secure connection, use `rediss` as the URI scheme.  It also adds two new flags, one to turn off TLS verification, `insecure-tls`, and one to pass in a custom CA cert that will be included in the CA pool, `tls-cert`.  I have been testing this via my own fork and it has proven to be pretty solid.  If there is interest in this change, please let me know if there's anything this PR is missing and I'll get that in there.