### PR TITLE
move vitess.io

### DIFF
--- a/goworker.go
+++ b/goworker.go
@@ -9,7 +9,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/cihub/seelog"
-	"github.com/youtube/vitess/go/pools"
+	"vitess.io/vitess/go/pools"
 )
 
 var (

--- a/redis.go
+++ b/redis.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/gomodule/redigo/redis"
-	"github.com/youtube/vitess/go/pools"
+	"vitess.io/vitess/go/pools"
 )
 
 var (


### PR DESCRIPTION
vitess is moved to vitess.io and is exposed as vitess.io/vitess/go now.

---

vitess's repository is big.
when goworker imports github.com/youtube/vitess/go, it import others packages from vitess.io/vitess/go,
so that big repository is download twice when `go get .../goworker`