### PR TITLE
Added missing prefillParallelism argument in redis.go newRedisPool function

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ func init() {
 		Concurrency:    2,
 		Namespace:      "resque:",
 		Interval:       5.0,
+		PrefillParallelism: 0,
 	}
 	goworker.SetSettings(settings)
 	goworker.Register("MyClass", myFunc)

--- a/redis.go
+++ b/redis.go
@@ -31,8 +31,8 @@ func newRedisFactory(uri string) pools.Factory {
 	}
 }
 
-func newRedisPool(uri string, capacity int, maxCapacity int, idleTimout time.Duration) *pools.ResourcePool {
-	return pools.NewResourcePool(newRedisFactory(uri), capacity, maxCapacity, idleTimout)
+func newRedisPool(uri string, capacity int, maxCapacity int, idleTimout time.Duration, prefillParallelism int) *pools.ResourcePool {
+	return pools.NewResourcePool(newRedisFactory(uri), capacity, maxCapacity, idleTimout, prefillParallelism)
 }
 
 func redisConnFromURI(uriString string) (*RedisConn, error) {


### PR DESCRIPTION
There were major changes in [see history](https://github.com/vitessio/vitess/commits/65cbfaf4c57b60c2af3ae6d573365c1b0f39f11c/go/pools). The changes on May 25th, 2019 broken [goworker](https://github.com/benmanns/goworker/blob/master/redis.go#L35) package. Added required parameter with default value ( default value 0 as defined in struct ) to fix the issue
